### PR TITLE
Use a CloudFront keypair instead of root keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ infra/terraform.tfstate*
 infra/terraform.tfvars
 infra/backend.tf
 infra/templates/email-invite.html
+infra/*.pem

--- a/infra/parameterstore.tf
+++ b/infra/parameterstore.tf
@@ -1,0 +1,13 @@
+resource "aws_ssm_parameter" "keypair_id" {
+  name        = "cloudfront_keypair_id"
+  description = "ID of the public key in CloudFront"
+  type        = "String"
+  value.      = aws_cloudfront_public_key.cookie_signer.id
+}
+
+resource "aws_ssm_parameter" "private_key" {
+  name        = "cloudfront_private_key"
+  description = "Private key for signing CloudFront cookies"
+  type        = "SecureString"
+  value       = file("private_key.pem")
+}


### PR DESCRIPTION
This is work in progress to deploy a CloudFront key pair instead of using the root-account key pair.
It was already documented in the README, but this should automate it to 100%.

The code is not tested yet.
